### PR TITLE
fix: check file existence in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc && node -e \"if (process.platform !== 'win32') require('child_process').execSync('chmod +x build/index.js')\"",
-    "postinstall": "node -e \"if (process.platform !== 'win32') require('child_process').execSync('chmod +x build/index.js')\"",
+    "postinstall": "node -e \"const fs=require('fs'); if (process.platform !== 'win32' && fs.existsSync('build/index.js')) require('child_process').execSync('chmod +x build/index.js')\"",
     "start": "node build/index.js",
     "dev": "tsc -w",
     "dev:server": "npm run build && npx @modelcontextprotocol/inspector -e DEBUG=true node build/index.js",


### PR DESCRIPTION
# 🐛 Fix: Resolve postinstall script error on fresh installs

## Problem

The `postinstall` script was failing during `npm install` because it tried to `chmod` the `build/index.js` file before it was created by the TypeScript compilation.

### Error Output

```console
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
...

> bitbucket-server@1.0.0 postinstall
> node -e "if (process.platform !== 'win32') require('child_process').execSync('chmod +x build/index.js')"

chmod: cannot access 'build/index.js': No such file or directory
Error: Command failed: chmod +x build/index.js
    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at checkExecSyncError (node:child_process:891:11)
    at Object.execSync (node:child_process:963:15)
    ...
npm error code 1
npm error command failed
```

### Root Cause

The `postinstall` script runs immediately after `npm install`, but at this point:

1. Dependencies are installed ✅
2. TypeScript compilation hasn't run yet ❌
3. The `build/` directory doesn't exist ❌
4. The `build/index.js` file doesn't exist ❌

## Solution

Added a file existence check in the `postinstall` script before attempting to set execute permissions.

### Code Changes

**Before:**

```json
"postinstall": "node -e \"if (process.platform !== 'win32') require('child_process').execSync('chmod +x build/index.js')\""
```

**After:**

```json
"postinstall": "node -e \"const fs=require('fs'); if (process.platform !== 'win32' && fs.existsSync('build/index.js')) require('child_process').execSync('chmod +x build/index.js')\""
```

### Logic Flow

1. Check if platform is not Windows ✅
2. **NEW:** Check if `build/index.js` file exists ✅
3. Only then execute `chmod +x build/index.js` ✅

## Testing

### ✅ Fresh Install Test

```bash
$ rm -rf node_modules package-lock.json build/
$ npm install
# No errors, completes successfully
```

### ✅ Build Process Test

```bash
$ npm run build
# Compiles TypeScript and sets proper permissions
$ ls -la build/index.js
-rwxr-xr-x 1 user user 14988 Jun 17 12:11 build/index.js
```

### ✅ Existing Functionality Test

```bash
# After build exists, postinstall still works correctly
$ npm install
# No errors, file permissions maintained
```

## Impact

### 🎯 Fixes

- ✅ Resolves installation errors for new users/contributors
- ✅ Eliminates "No such file or directory" error
- ✅ Improves developer experience for fresh clones

### 🔄 Maintains

- ✅ Existing build process functionality
- ✅ Execute permissions on built files
- ✅ Cross-platform compatibility (Windows check)
- ✅ No breaking changes

### 📈 Benefits

- Better onboarding experience for new contributors
- Reduced support burden for installation issues
- More robust installation process
- Maintains security (execute permissions still set when appropriate)

## Files Changed

- `package.json` - Modified `postinstall` script to include file existence check

## Backward Compatibility

✅ **Fully backward compatible** - no breaking changes

- Existing builds continue to work
- Execute permissions still set correctly
- Same behavior for all platforms

## Additional Notes

This is a minimal, safe fix that follows the principle of "fail gracefully". The script now:

1. Only attempts to modify permissions when the file actually exists
2. Maintains all existing functionality
3. Prevents installation failures on fresh setups

The fix is production-ready and has been tested on Linux environments.
