### PR TITLE
Add per-file truncation for diff output to handle large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Parameters:
 
 ### `get_diff`
 
-**Analyze code changes**: Retrieves the code differences showing exactly what was added, removed, or modified in the pull request.
+**Analyze code changes**: Retrieves the code differences showing exactly what was added, removed, or modified in the pull request. Supports per-file truncation to manage large diffs effectively.
 
 **Use cases:**
 - Review specific code changes
@@ -179,6 +179,7 @@ Parameters:
 - Analyze impact before merging
 - Inspect implementation details
 - Code quality assessment
+- Handle large files without overwhelming output
 
 Parameters:
 
@@ -186,6 +187,15 @@ Parameters:
 - `repository` (required): Repository slug
 - `prId` (required): Pull request ID
 - `contextLines`: Context lines around changes (default: 10)
+- `maxLinesPerFile`: Maximum lines to show per file (optional, uses BITBUCKET_DIFF_MAX_LINES_PER_FILE env var if not specified, set to 0 for no limit)
+
+**Large File Handling:**
+When a file exceeds the `maxLinesPerFile` limit, it shows:
+- File headers and metadata (always preserved)
+- First 60% of allowed lines from the beginning
+- Truncation message with file statistics
+- Last 40% of allowed lines from the end
+- Clear indication of how to see the complete diff
 
 ### `get_reviews`
 
@@ -393,6 +403,7 @@ The server requires configuration in the VSCode MCP settings file. Here's a samp
   - `BITBUCKET_TOKEN`: Personal access token
   - `BITBUCKET_USERNAME` and `BITBUCKET_PASSWORD`: Basic authentication credentials
 - `BITBUCKET_DEFAULT_PROJECT` (optional): Default project key to use when not specified in tool calls
+- `BITBUCKET_DIFF_MAX_LINES_PER_FILE` (optional): Default maximum lines to show per file in diffs. Set to prevent large files from overwhelming output. Can be overridden by the `maxLinesPerFile` parameter in `get_diff` calls.
 
 **Note**: With the new optional project support, you can now:
 


### PR DESCRIPTION
## Problem

When viewing pull request diffs that include large files (such as `poetry.lock`, `package-lock.json`, or generated files), the diff output becomes overwhelming and makes it difficult to review changes in other files. For example, a single `poetry.lock` file with thousands of lines can dominate the entire diff, hiding important changes in other files.

## Solution

This PR adds per-file truncation support to the `get_diff` tool, allowing users to limit the number of lines shown per individual file while preserving visibility of all files in the pull request.

## Key Features

- **Environment Variable**: `BITBUCKET_DIFF_MAX_LINES_PER_FILE` sets a default truncation limit
- **Parameter Override**: `maxLinesPerFile` parameter allows per-request customization  
- **Smart Truncation**: Shows first 60% + last 40% of content when truncating
- **Preserved Context**: File headers and metadata are always shown
- **Clear Messaging**: Truncation messages indicate what was hidden and how to see more
- **Backward Compatible**: No truncation by default, existing behavior unchanged
- **Flexible Control**: Set `maxLinesPerFile=0` to disable truncation entirely

## Example Usage

```bash
# Use environment default
export BITBUCKET_DIFF_MAX_LINES_PER_FILE=200
get_diff --project=PROJ --repository=repo --prId=123

# Override per request  
get_diff --project=PROJ --repository=repo --prId=123 --maxLinesPerFile=50

# No truncation
get_diff --project=PROJ --repository=repo --prId=123 --maxLinesPerFile=0
```

## Example Output

When a file exceeds the limit, it shows:
```diff
diff --git a/poetry.lock b/poetry.lock
... [file headers preserved]
@@ -1,140 +1,325 @@
+# First 60% of changes shown here
+import something
+...

[*** FILE TRUNCATED: 2,950 lines hidden from poetry.lock ***]
[*** File had 3,000 total lines, showing first 30 and last 20 ***]  
[*** Use maxLinesPerFile=0 to see complete diff ***]

+# Last 40% of changes shown here  
+final content...
```

## Testing

Tested with real-world PR containing a 3,200-line `poetry.lock` file:
- ✅ Large file properly truncated to manageable size
- ✅ Other files in PR remain completely visible  
- ✅ File headers and context preserved
- ✅ Clear truncation messaging provided
- ✅ Full diff available with `maxLinesPerFile=0`
- ✅ Backward compatibility maintained

## Impact  

This enhancement significantly improves the usability of the `get_diff` tool when working with pull requests that include large generated files, dependency files, or other verbose content, while maintaining full flexibility for users who need complete diffs.