### PR TITLE
Add review workflow, dashboard, cross-repo PR, and safe PR update tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ Parameters:
 - `sourceBranch` (required): Source branch containing changes
 - `targetBranch` (required): Target branch for merging
 - `reviewers`: Array of reviewer usernames
+- `sourceProject`: Project key of the source repository (for cross-repo PRs from forks)
+- `sourceRepository`: Slug of the source repository (for cross-repo PRs from forks)
+- `includeDefaultReviewers`: Automatically fetch and include default reviewers configured for the target branch (default: true)
+
+### `update_pull_request`
+
+**Safely update a pull request**: Modify the title, description, or reviewers of an existing pull request without losing any metadata. Uses a read-modify-write pattern to preserve all fields not explicitly changed.
+
+**Use cases:**
+
+- Fix PR title or description after creation
+- Add or replace reviewers without losing existing ones
+- Update PR metadata without affecting approval status
+
+Parameters:
+
+- `project`: Bitbucket project key (optional, uses BITBUCKET_DEFAULT_PROJECT if not provided)
+- `repository` (required): Repository slug
+- `prId` (required): Pull request ID to update
+- `title`: New title (if omitted, current title is preserved)
+- `description`: New description (if omitted, current description is preserved)
+- `reviewers`: New reviewer list as array of usernames (if omitted, current reviewers are preserved)
 
 ### `get_pull_request`
 
@@ -179,6 +201,7 @@ Parameters:
 - `prId` (required): Pull request ID
 - `text` (required): Comment content (supports Markdown)
 - `parentId`: Parent comment ID for threaded replies
+- `state`: Comment state: `OPEN` (default, published immediately) or `PENDING` (draft, visible only to you until review is published)
 
 ### `get_diff`
 
@@ -432,6 +455,98 @@ Parameters:
 - `repository` (required): Repository slug
 - `prId` (required): Pull request ID to remove approval from
 
+### `edit_comment`
+
+**Edit an existing comment**: Modify the text of a comment on a pull request. Works with both published and pending (draft) comments. Requires the comment version for optimistic locking.
+
+**Use cases:**
+
+- Fix typos or formatting in review comments
+- Update information in an existing comment
+- Reformat comments (e.g., to Conventional Comments style)
+
+Parameters:
+
+- `project`: Bitbucket project key (optional, uses BITBUCKET_DEFAULT_PROJECT if not provided)
+- `repository` (required): Repository slug
+- `prId` (required): Pull request ID the comment belongs to
+- `commentId` (required): ID of the comment to edit
+- `text` (required): New text content (supports Markdown)
+- `version` (required): Current version of the comment for optimistic locking (from `get_comments` or `add_comment` response)
+
+### `delete_comment`
+
+**Delete a comment**: Remove a comment from a pull request. Requires the comment version for optimistic locking.
+
+**Use cases:**
+
+- Remove incorrectly posted comments
+- Clean up draft comments that are no longer needed
+
+Parameters:
+
+- `project`: Bitbucket project key (optional, uses BITBUCKET_DEFAULT_PROJECT if not provided)
+- `repository` (required): Repository slug
+- `prId` (required): Pull request ID the comment belongs to
+- `commentId` (required): ID of the comment to delete
+- `version` (required): Current version of the comment for optimistic locking
+
+### `publish_review`
+
+**Publish a batch review**: Publish all pending (draft) comments at once, optionally setting your review status and adding an overview comment. This is the equivalent of clicking "Finish review" in the Bitbucket UI.
+
+**Use cases:**
+
+- Publish all draft review comments in a single action
+- Approve a PR along with review comments
+- Request changes with a "needs work" status and feedback
+
+Parameters:
+
+- `project`: Bitbucket project key (optional, uses BITBUCKET_DEFAULT_PROJECT if not provided)
+- `repository` (required): Repository slug
+- `prId` (required): Pull request ID
+- `commentText`: Optional overview comment for the review
+- `participantStatus`: Optional review status: `APPROVED` (ready to merge) or `NEEDS_WORK` (changes required). Omit for general feedback.
+
+### `get_code_insights`
+
+**Retrieve CI/CD analysis results**: Fetch Code Insights reports (SonarQube, security scans, etc.) and their annotations for a pull request.
+
+**Use cases:**
+
+- Check SonarQube quality gate status
+- Review security scan findings
+- Inspect code coverage metrics
+- See CI/CD analysis annotations per file
+
+Parameters:
+
+- `project`: Bitbucket project key (optional, uses BITBUCKET_DEFAULT_PROJECT if not provided)
+- `repository` (required): Repository slug
+- `prId` (required): Pull request ID
+
+### `get_dashboard_pull_requests`
+
+**Cross-repository PR dashboard**: List pull requests across all repositories for the authenticated user. Use this to see PRs you need to review, PRs you authored, or PRs you are participating in, without needing to specify each project and repository.
+
+**Use cases:**
+
+- See all PRs awaiting your review
+- List your own open PRs across all projects
+- Find recently merged PRs you participated in
+- Get an overview of your PR workload
+
+Parameters:
+
+- `state`: Filter by PR state: `OPEN` (default), `MERGED`, `DECLINED`, or `ALL`
+- `role`: Filter by your role: `AUTHOR`, `REVIEWER`, or `PARTICIPANT`
+- `participantStatus`: Filter by your review status: `APPROVED`, `UNAPPROVED`, or `NEEDS_WORK`
+- `order`: Sort order: `OLDEST` or `NEWEST` (default)
+- `closedSince`: Only include closed PRs updated after this timestamp (epoch ms)
+- `limit`: Number of PRs to return (default: 25)
+- `start`: Start index for pagination (default: 0)
+
 ## Usage Examples
 
 ### Listing Projects and Repositories
@@ -629,13 +744,20 @@ The server supports a read-only mode for deployments where you want to prevent a
 - `browse_repository` - Browse repository structure
 - `list_branches` - List repository branches
 - `list_commits` - Browse commit history
+- `get_code_insights` - Retrieve CI/CD analysis reports and annotations
+- `get_dashboard_pull_requests` - List PRs across all repositories for the authenticated user
 
 **Disabled tools in read-only mode:**
 
 - `create_pull_request` - Creating new pull requests
+- `update_pull_request` - Updating pull request title, description, or reviewers
 - `merge_pull_request` - Merging pull requests
 - `decline_pull_request` - Declining pull requests
 - `add_comment` - Adding comments to pull requests
+- `add_comment_inline` - Adding inline comments to pull requests
+- `edit_comment` - Editing existing comments
+- `delete_comment` - Deleting comments
+- `publish_review` - Publishing batch reviews
 - `delete_branch` - Deleting branches
 - `approve_pull_request` - Approving pull requests
 - `unapprove_pull_request` - Removing PR approvals

--- a/src/__tests__/index.integration.test.ts
+++ b/src/__tests__/index.integration.test.ts
@@ -9,6 +9,8 @@ import { vi } from "vitest";
 const mockAxios = {
   get: vi.fn(),
   post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
 };
 
 vi.mock("axios", () => ({
@@ -92,6 +94,12 @@ describe("BitbucketServer Integration Tests", () => {
         "delete_branch",
         "approve_pull_request",
         "unapprove_pull_request",
+        "edit_comment",
+        "delete_comment",
+        "publish_review",
+        "get_code_insights",
+        "get_dashboard_pull_requests",
+        "update_pull_request",
       ];
       expect(new Set(toolNames)).toEqual(new Set(expectedTools));
     });
@@ -415,6 +423,556 @@ describe("BitbucketServer Integration Tests", () => {
           ["APPROVED", "REVIEWED"].includes(r.action),
         ),
       ).toBe(true);
+    });
+  });
+
+  describe("create_pull_request cross-repo", () => {
+    test("should create a PR from a fork to upstream", async () => {
+      mockAxios.post.mockResolvedValueOnce({
+        data: { id: 200, title: "Cross-repo PR", state: "OPEN" },
+      });
+
+      const result = await client.callTool({
+        name: "create_pull_request",
+        arguments: {
+          project: "DRC",
+          repository: "service",
+          title: "Cross-repo PR",
+          description: "From fork",
+          sourceBranch: "feature-branch",
+          targetBranch: "master",
+          sourceProject: "~JOHN",
+          sourceRepository: "dr-service",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.id).toBe(200);
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/DRC/repos/service/pull-requests",
+        expect.objectContaining({
+          fromRef: expect.objectContaining({
+            id: "refs/heads/feature-branch",
+            repository: { slug: "dr-service", project: { key: "~JOHN" } },
+          }),
+          toRef: expect.objectContaining({
+            id: "refs/heads/master",
+            repository: { slug: "service", project: { key: "DRC" } },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("add_comment with state", () => {
+    test("should create a pending draft comment", async () => {
+      mockAxios.post.mockResolvedValueOnce({
+        data: { id: 100, text: "Draft", state: "PENDING" },
+      });
+
+      const result = await client.callTool({
+        name: "add_comment",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          text: "Draft",
+          state: "PENDING",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.state).toBe("PENDING");
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments",
+        { text: "Draft", state: "PENDING" },
+      );
+    });
+  });
+
+  describe("add_comment_inline with state", () => {
+    test("should create a pending inline comment", async () => {
+      mockAxios.post.mockResolvedValueOnce({
+        data: { id: 101, text: "Inline draft", state: "PENDING" },
+      });
+
+      const result = await client.callTool({
+        name: "add_comment_inline",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          text: "Inline draft",
+          filePath: "src/main.ts",
+          line: 42,
+          lineType: "ADDED",
+          state: "PENDING",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.state).toBe("PENDING");
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments",
+        expect.objectContaining({
+          text: "Inline draft",
+          state: "PENDING",
+          anchor: expect.objectContaining({
+            path: "src/main.ts",
+            line: 42,
+            lineType: "ADDED",
+            diffType: "EFFECTIVE",
+            fileType: "TO",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("edit_comment tool", () => {
+    test("should edit an existing comment", async () => {
+      mockAxios.put.mockResolvedValueOnce({
+        data: { id: 789, text: "Updated text", version: 1 },
+      });
+
+      const result = await client.callTool({
+        name: "edit_comment",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          commentId: 789,
+          text: "Updated text",
+          version: 0,
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.text).toBe("Updated text");
+      expect(parsed.version).toBe(1);
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments/789",
+        { text: "Updated text", version: 0 },
+      );
+    });
+  });
+
+  describe("delete_comment tool", () => {
+    test("should delete a comment", async () => {
+      mockAxios.delete.mockResolvedValueOnce({ status: 204 });
+
+      const result = await client.callTool({
+        name: "delete_comment",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          commentId: 789,
+          version: 1,
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.deleted).toBe(true);
+      expect(parsed.commentId).toBe(789);
+
+      expect(mockAxios.delete).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments/789",
+        { params: { version: 1 } },
+      );
+    });
+  });
+
+  describe("publish_review tool", () => {
+    test("should publish review with approval", async () => {
+      mockAxios.put.mockResolvedValueOnce({ data: {} });
+
+      const result = await client.callTool({
+        name: "publish_review",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          commentText: "LGTM",
+          participantStatus: "APPROVED",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0].type).toBe("text");
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/review",
+        { commentText: "LGTM", participantStatus: "APPROVED" },
+      );
+    });
+
+    test("should publish review without status", async () => {
+      mockAxios.put.mockResolvedValueOnce({ data: {} });
+
+      await client.callTool({
+        name: "publish_review",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+        },
+      });
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/review",
+        { commentText: null },
+      );
+    });
+  });
+
+  describe("get_code_insights tool", () => {
+    test("should fetch reports and annotations", async () => {
+      mockAxios.get
+        .mockResolvedValueOnce({
+          data: {
+            values: [
+              { key: "sonarqube", title: "SonarQube", result: "PASS" },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            values: [
+              { path: "src/main.ts", line: 10, message: "Code smell" },
+            ],
+          },
+        });
+
+      const result = await client.callTool({
+        name: "get_code_insights",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.reports).toHaveLength(1);
+      expect(parsed.reports[0].key).toBe("sonarqube");
+      expect(parsed.annotations["sonarqube"]).toHaveLength(1);
+      expect(parsed.annotations["sonarqube"][0].message).toBe("Code smell");
+    });
+
+    test("should handle reports with no annotations", async () => {
+      mockAxios.get
+        .mockResolvedValueOnce({
+          data: { values: [{ key: "scanner", title: "Scanner" }] },
+        })
+        .mockRejectedValueOnce(new Error("Not found"));
+
+      const result = await client.callTool({
+        name: "get_code_insights",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.reports).toHaveLength(1);
+      expect(parsed.annotations["scanner"]).toEqual([]);
+    });
+  });
+
+  describe("add_comment with severity", () => {
+    test("should create a task (BLOCKER comment)", async () => {
+      mockAxios.post.mockResolvedValueOnce({
+        data: { id: 102, text: "Fix this", severity: "BLOCKER" },
+      });
+
+      const result = await client.callTool({
+        name: "add_comment",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          text: "Fix this",
+          severity: "BLOCKER",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.severity).toBe("BLOCKER");
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments",
+        { text: "Fix this", severity: "BLOCKER" },
+      );
+    });
+  });
+
+  describe("edit_comment with severity", () => {
+    test("should convert a comment to task", async () => {
+      mockAxios.put.mockResolvedValueOnce({
+        data: { id: 789, text: "Now a task", version: 1, severity: "BLOCKER" },
+      });
+
+      const result = await client.callTool({
+        name: "edit_comment",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 1,
+          commentId: 789,
+          text: "Now a task",
+          version: 0,
+          severity: "BLOCKER",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.severity).toBe("BLOCKER");
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/1/comments/789",
+        { text: "Now a task", version: 0, severity: "BLOCKER" },
+      );
+    });
+  });
+
+  describe("get_dashboard_pull_requests tool", () => {
+    test("should fetch PRs for the authenticated user", async () => {
+      mockAxios.get.mockResolvedValueOnce({
+        data: {
+          size: 1,
+          values: [
+            {
+              id: 42,
+              title: "Some PR",
+              state: "OPEN",
+              properties: { commentCount: 3, openTaskCount: 1 },
+            },
+          ],
+        },
+      });
+
+      const result = await client.callTool({
+        name: "get_dashboard_pull_requests",
+        arguments: { role: "REVIEWER", limit: 10 },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.size).toBe(1);
+      expect(parsed.values[0].title).toBe("Some PR");
+
+      expect(mockAxios.get).toHaveBeenCalledWith("/dashboard/pull-requests", {
+        params: { limit: 10, start: 0, role: "REVIEWER" },
+      });
+    });
+
+    test("should pass all filter params", async () => {
+      mockAxios.get.mockResolvedValueOnce({
+        data: { size: 0, values: [] },
+      });
+
+      await client.callTool({
+        name: "get_dashboard_pull_requests",
+        arguments: {
+          state: "OPEN",
+          role: "AUTHOR",
+          participantStatus: "APPROVED",
+          order: "NEWEST",
+          closedSince: 1700000000000,
+        },
+      });
+
+      expect(mockAxios.get).toHaveBeenCalledWith("/dashboard/pull-requests", {
+        params: {
+          limit: 25,
+          start: 0,
+          state: "OPEN",
+          role: "AUTHOR",
+          participantStatus: "APPROVED",
+          order: "NEWEST",
+          closedSince: 1700000000000,
+        },
+      });
+    });
+  });
+
+  describe("create_pull_request with default reviewers", () => {
+    test("should fetch and include default reviewers when flag is true", async () => {
+      // Repo ID lookup
+      mockAxios.get.mockResolvedValueOnce({ data: { id: 100 } });
+      // Default reviewers
+      mockAxios.get.mockResolvedValueOnce({
+        data: [
+          { name: "default-reviewer-1" },
+          { name: "default-reviewer-2" },
+        ],
+      });
+      // PR creation
+      mockAxios.post.mockResolvedValueOnce({
+        data: { id: 300, title: "Test", reviewers: [] },
+      });
+
+      await client.callTool({
+        name: "create_pull_request",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          title: "Test",
+          description: "",
+          sourceBranch: "feature",
+          targetBranch: "main",
+        },
+      });
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests",
+        expect.objectContaining({
+          reviewers: expect.arrayContaining([
+            { user: { name: "default-reviewer-1" } },
+            { user: { name: "default-reviewer-2" } },
+          ]),
+        }),
+      );
+    });
+
+    test("should merge explicit and default reviewers without duplicates", async () => {
+      mockAxios.get.mockResolvedValueOnce({ data: { id: 100 } });
+      mockAxios.get.mockResolvedValueOnce({
+        data: [{ name: "user1" }, { name: "user2" }],
+      });
+      mockAxios.post.mockResolvedValueOnce({ data: { id: 301 } });
+
+      await client.callTool({
+        name: "create_pull_request",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          title: "Test",
+          description: "",
+          sourceBranch: "feature",
+          targetBranch: "main",
+          reviewers: ["user1", "user3"],
+        },
+      });
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests",
+        expect.objectContaining({
+          reviewers: [
+            { user: { name: "user1" } },
+            { user: { name: "user3" } },
+            { user: { name: "user2" } },
+          ],
+        }),
+      );
+    });
+
+    test("should skip default reviewers when flag is false", async () => {
+      mockAxios.post.mockResolvedValueOnce({ data: { id: 302 } });
+
+      await client.callTool({
+        name: "create_pull_request",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          title: "Test",
+          description: "",
+          sourceBranch: "feature",
+          targetBranch: "main",
+          includeDefaultReviewers: false,
+        },
+      });
+
+      // Should NOT have called GET for repo ID or default reviewers
+      expect(mockAxios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update_pull_request tool", () => {
+    test("should update title while preserving reviewers", async () => {
+      mockAxios.get.mockResolvedValueOnce({
+        data: {
+          id: 42,
+          version: 3,
+          title: "Old title",
+          description: "Desc",
+          reviewers: [{ user: { name: "reviewer1" } }],
+        },
+      });
+      mockAxios.put.mockResolvedValueOnce({
+        data: { id: 42, version: 4, title: "New title" },
+      });
+
+      const result = await client.callTool({
+        name: "update_pull_request",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 42,
+          title: "New title",
+        },
+      });
+
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+      expect(parsed.title).toBe("New title");
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/42",
+        expect.objectContaining({
+          title: "New title",
+          description: "Desc",
+          reviewers: [{ user: { name: "reviewer1" } }],
+        }),
+      );
+    });
+
+    test("should replace reviewers when explicitly provided", async () => {
+      mockAxios.get.mockResolvedValueOnce({
+        data: {
+          id: 42,
+          version: 3,
+          title: "Title",
+          description: "Desc",
+          reviewers: [{ user: { name: "old-reviewer" } }],
+        },
+      });
+      mockAxios.put.mockResolvedValueOnce({
+        data: { id: 42, version: 4 },
+      });
+
+      await client.callTool({
+        name: "update_pull_request",
+        arguments: {
+          project: "TEST",
+          repository: "my-repo",
+          prId: 42,
+          reviewers: ["new-reviewer"],
+        },
+      });
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        "/projects/TEST/repos/my-repo/pull-requests/42",
+        expect.objectContaining({
+          reviewers: [{ user: { name: "new-reviewer" } }],
+        }),
+      );
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,8 @@ interface MergeOptions {
 interface CommentOptions {
   text: string;
   parentId?: number;
+  state?: 'OPEN' | 'PENDING';
+  severity?: 'NORMAL' | 'BLOCKER';
 }
 
 interface InlineCommentOptions extends CommentOptions {
@@ -80,6 +82,41 @@ interface PullRequestInput extends RepositoryParams {
   sourceBranch: string;
   targetBranch: string;
   reviewers?: string[];
+  sourceProject?: string;
+  sourceRepository?: string;
+  includeDefaultReviewers?: boolean;
+}
+
+interface UpdatePullRequestInput extends RepositoryParams {
+  prId: number;
+  title?: string;
+  description?: string;
+  reviewers?: string[];
+}
+
+interface EditCommentOptions {
+  commentId: number;
+  text: string;
+  version: number;
+  severity?: 'NORMAL' | 'BLOCKER';
+}
+
+interface DashboardPullRequestsOptions extends ListOptions {
+  state?: 'OPEN' | 'MERGED' | 'DECLINED' | 'ALL';
+  role?: 'AUTHOR' | 'REVIEWER' | 'PARTICIPANT';
+  participantStatus?: 'APPROVED' | 'UNAPPROVED' | 'NEEDS_WORK';
+  order?: 'OLDEST' | 'NEWEST';
+  closedSince?: number;
+}
+
+interface DeleteCommentOptions {
+  commentId: number;
+  version: number;
+}
+
+interface PublishReviewOptions {
+  commentText?: string;
+  participantStatus?: 'APPROVED' | 'NEEDS_WORK' | null;
 }
 
 interface ListOptions {
@@ -220,7 +257,7 @@ export class BitbucketServer {
   }
 
   private setupToolHandlers() {
-    const readOnlyTools = ['list_projects', 'list_repositories', 'get_pull_request', 'list_pull_requests', 'get_diff', 'get_reviews', 'get_activities', 'get_comments', 'search', 'get_file_content', 'browse_repository', 'list_branches', 'list_commits'];
+    const readOnlyTools = ['list_projects', 'list_repositories', 'get_pull_request', 'list_pull_requests', 'get_diff', 'get_reviews', 'get_activities', 'get_comments', 'search', 'get_file_content', 'browse_repository', 'list_branches', 'list_commits', 'get_code_insights', 'get_dashboard_pull_requests'];
     
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: [
@@ -263,9 +300,32 @@ export class BitbucketServer {
                 type: 'array',
                 items: { type: 'string' },
                 description: 'Array of Bitbucket usernames to assign as reviewers for this pull request.'
-              }
+              },
+              sourceProject: { type: 'string', description: 'Project key of the source repository when creating a cross-repo PR from a fork. If omitted, defaults to the same project as the target.' },
+              sourceRepository: { type: 'string', description: 'Slug of the source repository when creating a cross-repo PR from a fork. If omitted, defaults to the same repository as the target.' },
+              includeDefaultReviewers: { type: 'boolean', description: 'Automatically fetch and include default reviewers configured for the target branch. Defaults to true.' }
             },
             required: ['repository', 'title', 'sourceBranch', 'targetBranch']
+          }
+        },
+        {
+          name: 'update_pull_request',
+          description: 'Update an existing pull request title, description, or reviewers. Safely preserves all fields not explicitly changed (uses read-modify-write to avoid losing reviewers or other metadata).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
+              repository: { type: 'string', description: 'Repository slug containing the pull request.' },
+              prId: { type: 'number', description: 'Pull request ID to update.' },
+              title: { type: 'string', description: 'New title for the pull request.' },
+              description: { type: 'string', description: 'New description for the pull request. Supports Markdown.' },
+              reviewers: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Replace the reviewers list with these usernames. If omitted, existing reviewers are preserved.'
+              }
+            },
+            required: ['repository', 'prId']
           }
         },
         {
@@ -324,7 +384,9 @@ export class BitbucketServer {
               repository: { type: 'string', description: 'Repository slug containing the pull request.' },
               prId: { type: 'number', description: 'Pull request ID to comment on.' },
               text: { type: 'string', description: 'Comment text content. Supports Markdown formatting for code blocks, links, and emphasis.' },
-              parentId: { type: 'number', description: 'ID of parent comment to reply to. Omit for top-level comments.' }
+              parentId: { type: 'number', description: 'ID of parent comment to reply to. Omit for top-level comments.' },
+              state: { type: 'string', enum: ['OPEN', 'PENDING'], description: 'Comment state. Use PENDING to create a draft comment visible only to you until you publish the review. Defaults to OPEN.' },
+              severity: { type: 'string', enum: ['NORMAL', 'BLOCKER'], description: 'Comment severity. Use BLOCKER to create a task instead of a regular comment. Defaults to NORMAL.' }
             },
             required: ['repository', 'prId', 'text']
           }
@@ -342,7 +404,9 @@ export class BitbucketServer {
               parentId: { type: 'number', description: 'ID of parent comment to reply to. Omit for top-level comments.' },
               filePath: { type: 'string', description: 'Path to the file in the repository where the comment should be added (e.g., "src/main.py", "README.md").' },
               line: { type: 'number', description: 'Line number in the file to attach the comment to (1-based).' },
-              lineType: { type: 'string', enum: ['ADDED', 'REMOVED'], description: 'Type of change the comment is associated with: ADDED for additions, REMOVED for deletions.' }
+              lineType: { type: 'string', enum: ['ADDED', 'REMOVED'], description: 'Type of change the comment is associated with: ADDED for additions, REMOVED for deletions.' },
+              state: { type: 'string', enum: ['OPEN', 'PENDING'], description: 'Comment state. Use PENDING to create a draft comment visible only to you until you publish the review. Defaults to OPEN.' },
+              severity: { type: 'string', enum: ['NORMAL', 'BLOCKER'], description: 'Comment severity. Use BLOCKER to create a task instead of a regular comment. Defaults to NORMAL.' }
             },
             required: ['repository', 'prId', 'text', 'filePath', 'line', 'lineType']
           }
@@ -546,6 +610,82 @@ export class BitbucketServer {
             },
             required: ['repository', 'prId']
           }
+        },
+        {
+          name: 'edit_comment',
+          description: 'Edit an existing comment on a pull request. Use this to fix typos, update information, or reformat comments. Requires the comment version for optimistic locking.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
+              repository: { type: 'string', description: 'Repository slug containing the pull request.' },
+              prId: { type: 'number', description: 'Pull request ID the comment belongs to.' },
+              commentId: { type: 'number', description: 'ID of the comment to edit.' },
+              text: { type: 'string', description: 'New text content for the comment. Supports Markdown.' },
+              version: { type: 'number', description: 'Current version of the comment (for optimistic locking). Obtain from get_comments or add_comment response.' },
+              severity: { type: 'string', enum: ['NORMAL', 'BLOCKER'], description: 'Comment severity. Use BLOCKER to convert to a task, NORMAL to convert back to a comment.' }
+            },
+            required: ['repository', 'prId', 'commentId', 'text', 'version']
+          }
+        },
+        {
+          name: 'delete_comment',
+          description: 'Delete a comment from a pull request. Requires the comment version for optimistic locking.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
+              repository: { type: 'string', description: 'Repository slug containing the pull request.' },
+              prId: { type: 'number', description: 'Pull request ID the comment belongs to.' },
+              commentId: { type: 'number', description: 'ID of the comment to delete.' },
+              version: { type: 'number', description: 'Current version of the comment (for optimistic locking). Obtain from get_comments or add_comment response.' }
+            },
+            required: ['repository', 'prId', 'commentId', 'version']
+          }
+        },
+        {
+          name: 'publish_review',
+          description: 'Publish all pending (draft) review comments on a pull request at once. Optionally set your review status to APPROVED or NEEDS_WORK, and add an overview comment. This is the batch operation that transitions all PENDING comments to published.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
+              repository: { type: 'string', description: 'Repository slug containing the pull request.' },
+              prId: { type: 'number', description: 'Pull request ID to publish the review on.' },
+              commentText: { type: 'string', description: 'Optional overview comment to include with the review.' },
+              participantStatus: { type: 'string', enum: ['APPROVED', 'NEEDS_WORK'], description: 'Optional review status. APPROVED marks the PR as ready to merge. NEEDS_WORK indicates changes are required. Omit for general feedback without changing status.' }
+            },
+            required: ['repository', 'prId']
+          }
+        },
+        {
+          name: 'get_code_insights',
+          description: 'Retrieve Code Insights reports (SonarQube, security scans, etc.) and their annotations for a pull request. Use this to check quality gates, code coverage, security findings, and other CI/CD analysis results.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
+              repository: { type: 'string', description: 'Repository slug containing the pull request.' },
+              prId: { type: 'number', description: 'Pull request ID to get insights for.' }
+            },
+            required: ['repository', 'prId']
+          }
+        },
+        {
+          name: 'get_dashboard_pull_requests',
+          description: 'List pull requests across all repositories for the authenticated user. Use this to see PRs you need to review, PRs you authored, or PRs you are participating in. Returns PRs from all projects and repositories without needing to specify each one.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              state: { type: 'string', enum: ['OPEN', 'MERGED', 'DECLINED', 'ALL'], description: 'Filter by PR state (default: OPEN).' },
+              role: { type: 'string', enum: ['AUTHOR', 'REVIEWER', 'PARTICIPANT'], description: 'Filter by your role in the PR.' },
+              participantStatus: { type: 'string', enum: ['APPROVED', 'UNAPPROVED', 'NEEDS_WORK'], description: 'Filter by your review status on the PR.' },
+              order: { type: 'string', enum: ['OLDEST', 'NEWEST'], description: 'Sort order (default: NEWEST).' },
+              closedSince: { type: 'number', description: 'Only include closed PRs updated after this timestamp (epoch ms). Useful for finding recently merged or declined PRs.' },
+              limit: { type: 'number', description: 'Number of PRs to return (default: 25).' },
+              start: { type: 'number', description: 'Start index for pagination (default: 0).' }
+            }
+          }
         }
       ].filter(tool => !this.config.readOnly || readOnlyTools.includes(tool.name))
     }));
@@ -598,8 +738,13 @@ export class BitbucketServer {
                 'Invalid pull request input parameters'
               );
             }
-            // Ensure project is set
-            const createArgs = { ...args, project: getProject(args.project) };
+            const createArgs = {
+              ...args,
+              project: getProject(args.project),
+              sourceProject: args.sourceProject as string | undefined,
+              sourceRepository: args.sourceRepository as string | undefined,
+              includeDefaultReviewers: args.includeDefaultReviewers !== false
+            };
             return await this.createPullRequest(createArgs);
           }
 
@@ -610,6 +755,17 @@ export class BitbucketServer {
               prId: args.prId as number
             };
             return await this.getPullRequest(getPrParams);
+          }
+
+          case 'update_pull_request': {
+            return await this.updatePullRequest({
+              project: getProject(args.project as string),
+              repository: args.repository as string,
+              prId: args.prId as number,
+              title: args.title as string | undefined,
+              description: args.description as string | undefined,
+              reviewers: args.reviewers as string[] | undefined
+            });
           }
 
           case 'merge_pull_request': {
@@ -641,11 +797,13 @@ export class BitbucketServer {
             };
             return await this.addComment(commentPrParams, {
               text: args.text as string,
-              parentId: args.parentId as number
+              parentId: args.parentId as number,
+              state: args.state as 'OPEN' | 'PENDING' | undefined,
+              severity: args.severity as 'NORMAL' | 'BLOCKER' | undefined
             });
           }
 
-           case 'add_comment_inline': {
+          case 'add_comment_inline': {
             const commentPrParams: PullRequestParams = {
               project: getProject(args.project as string),
               repository: args.repository as string,
@@ -656,7 +814,9 @@ export class BitbucketServer {
               parentId: args.parentId as number,
               filePath: args.filePath as string,
               line: args.line as number,
-              lineType: args.lineType as 'ADDED' | 'REMOVED'
+              lineType: args.lineType as 'ADDED' | 'REMOVED',
+              state: args.state as 'OPEN' | 'PENDING' | undefined,
+              severity: args.severity as 'NORMAL' | 'BLOCKER' | undefined
             });
           }
 
@@ -791,6 +951,65 @@ export class BitbucketServer {
             return await this.unapprovePullRequest(unapprovePrParams);
           }
 
+          case 'edit_comment': {
+            const editPrParams: PullRequestParams = {
+              project: getProject(args.project as string),
+              repository: args.repository as string,
+              prId: args.prId as number
+            };
+            return await this.editComment(editPrParams, {
+              commentId: args.commentId as number,
+              text: args.text as string,
+              version: args.version as number,
+              severity: args.severity as 'NORMAL' | 'BLOCKER' | undefined
+            });
+          }
+
+          case 'delete_comment': {
+            const deletePrParams: PullRequestParams = {
+              project: getProject(args.project as string),
+              repository: args.repository as string,
+              prId: args.prId as number
+            };
+            return await this.deleteComment(deletePrParams, {
+              commentId: args.commentId as number,
+              version: args.version as number
+            });
+          }
+
+          case 'publish_review': {
+            const reviewPrParams: PullRequestParams = {
+              project: getProject(args.project as string),
+              repository: args.repository as string,
+              prId: args.prId as number
+            };
+            return await this.publishReview(reviewPrParams, {
+              commentText: args.commentText as string | undefined,
+              participantStatus: args.participantStatus as 'APPROVED' | 'NEEDS_WORK' | undefined
+            });
+          }
+
+          case 'get_code_insights': {
+            const insightsPrParams: PullRequestParams = {
+              project: getProject(args.project as string),
+              repository: args.repository as string,
+              prId: args.prId as number
+            };
+            return await this.getCodeInsights(insightsPrParams);
+          }
+
+          case 'get_dashboard_pull_requests': {
+            return await this.getDashboardPullRequests({
+              state: args.state as DashboardPullRequestsOptions['state'],
+              role: args.role as DashboardPullRequestsOptions['role'],
+              participantStatus: args.participantStatus as DashboardPullRequestsOptions['participantStatus'],
+              order: args.order as DashboardPullRequestsOptions['order'],
+              closedSince: args.closedSince as number | undefined,
+              limit: args.limit as number | undefined,
+              start: args.start as number | undefined
+            });
+          }
+
           default:
             throw new McpError(
               ErrorCode.MethodNotFound,
@@ -887,6 +1106,49 @@ export class BitbucketServer {
   }
 
   private async createPullRequest(input: PullRequestInput) {
+    const sourceProject = input.sourceProject ?? input.project;
+    const sourceRepo = input.sourceRepository ?? input.repository;
+
+    const reviewers = input.reviewers?.map(username => ({ user: { name: username } })) ?? [];
+
+    if (input.includeDefaultReviewers !== false) {
+      try {
+        const targetRepoResponse = await this.api.get(
+          `/projects/${input.project}/repos/${input.repository}`
+        );
+        const targetRepoId = targetRepoResponse.data.id;
+
+        const sourceRepoId = sourceProject === input.project && sourceRepo === input.repository
+          ? targetRepoId
+          : (await this.api.get(`/projects/${sourceProject}/repos/${sourceRepo}`)).data.id;
+
+        const defaultReviewersResponse = await this.api.get(
+          `/projects/${input.project}/repos/${input.repository}/reviewers`,
+          {
+            baseURL: `${this.config.baseUrl}/rest/default-reviewers/1.0`,
+            params: {
+              sourceRepoId,
+              targetRepoId,
+              sourceRefId: input.sourceBranch,
+              targetRefId: input.targetBranch
+            }
+          }
+        );
+
+        const defaultReviewers = (defaultReviewersResponse.data ?? [])
+          .map((user: { name: string }) => ({ user: { name: user.name } }));
+
+        const existingNames = new Set(reviewers.map(r => r.user.name));
+        for (const dr of defaultReviewers) {
+          if (!existingNames.has(dr.user.name)) {
+            reviewers.push(dr);
+          }
+        }
+      } catch {
+        logger.warn('Could not fetch default reviewers, proceeding without them');
+      }
+    }
+
     const response = await this.api.post(
       `/projects/${input.project}/repos/${input.repository}/pull-requests`,
       {
@@ -895,8 +1157,8 @@ export class BitbucketServer {
         fromRef: {
           id: `refs/heads/${input.sourceBranch}`,
           repository: {
-            slug: input.repository,
-            project: { key: input.project }
+            slug: sourceRepo,
+            project: { key: sourceProject }
           }
         },
         toRef: {
@@ -906,8 +1168,41 @@ export class BitbucketServer {
             project: { key: input.project }
           }
         },
-        reviewers: input.reviewers?.map(username => ({ user: { name: username } }))
+        reviewers: reviewers.length > 0 ? reviewers : undefined
       }
+    );
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }]
+    };
+  }
+
+  private async updatePullRequest(input: UpdatePullRequestInput) {
+    const { project, repository, prId } = input;
+
+    if (!project || !repository || !prId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Project, repository, and prId are required'
+      );
+    }
+
+    const current = await this.api.get(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}`
+    );
+
+    const updated = {
+      ...current.data,
+      title: input.title ?? current.data.title,
+      description: input.description ?? current.data.description,
+      reviewers: input.reviewers
+        ? input.reviewers.map(username => ({ user: { name: username } }))
+        : current.data.reviewers
+    };
+
+    const response = await this.api.put(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}`,
+      updated
     );
 
     return {
@@ -917,7 +1212,7 @@ export class BitbucketServer {
 
   private async getPullRequest(params: PullRequestParams) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId) {
       throw new McpError(
         ErrorCode.InvalidParams,
@@ -997,21 +1292,23 @@ export class BitbucketServer {
 
   private async addComment(params: PullRequestParams, options: CommentOptions) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId) {
       throw new McpError(
         ErrorCode.InvalidParams,
         'Project, repository, and prId are required'
       );
     }
-    
-    const { text, parentId } = options;
-    
+
+    const { text, parentId, state, severity } = options;
+
     const response = await this.api.post(
       `/projects/${project}/repos/${repository}/pull-requests/${prId}/comments`,
       {
         text,
-        parent: parentId ? { id: parentId } : undefined
+        parent: parentId ? { id: parentId } : undefined,
+        ...(state && { state }),
+        ...(severity && { severity })
       }
     );
 
@@ -1022,31 +1319,155 @@ export class BitbucketServer {
 
   private async addCommentInline(params: PullRequestParams, options: InlineCommentOptions) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId || !options.filePath || !options.line || !options.lineType) {
       throw new McpError(
         ErrorCode.InvalidParams,
         'Project, repository, prId, filePath, line, and lineType are required'
       );
     }
-    
-    const { text, parentId } = options;
-    
+
+    const { text, parentId, state, severity } = options;
+
     const response = await this.api.post(
       `/projects/${project}/repos/${repository}/pull-requests/${prId}/comments`,
       {
         text,
         parent: parentId ? { id: parentId } : undefined,
+        ...(state && { state }),
+        ...(severity && { severity }),
         anchor: {
           path: options.filePath,
           lineType: options.lineType,
           line: options.line,
           diffType: 'EFFECTIVE',
-          fileType: 'TO',}
+          fileType: 'TO',
+        }
       }
     );
 
-    logger.error(response);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }]
+    };
+  }
+
+  private async editComment(params: PullRequestParams, options: EditCommentOptions) {
+    const { project, repository, prId } = params;
+
+    if (!project || !repository || !prId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Project, repository, and prId are required'
+      );
+    }
+
+    const response = await this.api.put(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/comments/${options.commentId}`,
+      {
+        text: options.text,
+        version: options.version,
+        ...(options.severity && { severity: options.severity })
+      }
+    );
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }]
+    };
+  }
+
+  private async deleteComment(params: PullRequestParams, options: DeleteCommentOptions) {
+    const { project, repository, prId } = params;
+
+    if (!project || !repository || !prId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Project, repository, and prId are required'
+      );
+    }
+
+    await this.api.delete(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/comments/${options.commentId}`,
+      { params: { version: options.version } }
+    );
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ deleted: true, commentId: options.commentId }, null, 2) }]
+    };
+  }
+
+  private async publishReview(params: PullRequestParams, options: PublishReviewOptions) {
+    const { project, repository, prId } = params;
+
+    if (!project || !repository || !prId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Project, repository, and prId are required'
+      );
+    }
+
+    const response = await this.api.put(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/review`,
+      {
+        commentText: options.commentText ?? null,
+        ...(options.participantStatus && { participantStatus: options.participantStatus })
+      }
+    );
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(response.data ?? { published: true }, null, 2) }]
+    };
+  }
+
+  private async getCodeInsights(params: PullRequestParams) {
+    const { project, repository, prId } = params;
+
+    if (!project || !repository || !prId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Project, repository, and prId are required'
+      );
+    }
+
+    const reportsResponse = await this.api.get(
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/reports`,
+      { baseURL: `${this.config.baseUrl}/rest/insights/latest` }
+    );
+
+    const reports = reportsResponse.data.values ?? [];
+    const result: { reports: unknown[]; annotations: Record<string, unknown[]> } = {
+      reports,
+      annotations: {}
+    };
+
+    for (const report of reports) {
+      const reportKey = (report as { key: string }).key;
+      try {
+        const annotationsResponse = await this.api.get(
+          `/projects/${project}/repos/${repository}/pull-requests/${prId}/reports/${reportKey}/annotations`,
+          { baseURL: `${this.config.baseUrl}/rest/insights/latest` }
+        );
+        result.annotations[reportKey] = annotationsResponse.data.values ?? [];
+      } catch {
+        result.annotations[reportKey] = [];
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+    };
+  }
+
+  private async getDashboardPullRequests(options: DashboardPullRequestsOptions = {}) {
+    const { limit = 25, start = 0, state, role, participantStatus, order, closedSince } = options;
+
+    const params: Record<string, unknown> = { limit, start };
+    if (state) params.state = state;
+    if (role) params.role = role;
+    if (participantStatus) params.participantStatus = participantStatus;
+    if (order) params.order = order;
+    if (closedSince) params.closedSince = closedSince;
+
+    const response = await this.api.get('/dashboard/pull-requests', { params });
 
     return {
       content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }]


### PR DESCRIPTION
New tools and enhancements for code review workflows, cross-repository development, and CI/CD visibility.

## New tools

- **`edit_comment`**: edit an existing PR comment (with optimistic locking via `version`)
- **`delete_comment`**: delete a PR comment
- **`publish_review`**: publish all pending (draft) comments at once, optionally setting review status (`APPROVED` / `NEEDS_WORK`) and adding an overview comment. Uses an undocumented but functional `PUT .../pull-requests/{id}/review` endpoint, verified on Bitbucket Server 8.9.4.
- **`get_code_insights`**: fetch Code Insights reports (SonarQube, security scans) and their per-file annotations
- **`get_dashboard_pull_requests`**: list PRs across all repositories for the authenticated user, with filtering by role (AUTHOR / REVIEWER / PARTICIPANT), state, review status, and sort order
- **`update_pull_request`**: safely update title, description, or reviewers of an existing PR using a read-modify-write pattern that preserves all fields not explicitly changed (prevents the common issue of losing reviewers when updating via the API)

## Enhancements to existing tools

- **`create_pull_request`**: new `sourceProject` and `sourceRepository` params for cross-repo PRs from forks; new `includeDefaultReviewers` flag (default true) that automatically fetches and includes default reviewers configured for the target branch
- **`add_comment`** / **`add_comment_inline`**: new `state` param (`OPEN` | `PENDING`) for draft comments, new `severity` param (`NORMAL` | `BLOCKER`) to create tasks instead of regular comments
- **`edit_comment`**: also accepts `severity` to convert between comments and tasks