### PR TITLE
feat: add pagination support to get_activities, get_comments, get_reviews

### DIFF
--- a/src/__tests__/index.integration.test.ts
+++ b/src/__tests__/index.integration.test.ts
@@ -403,6 +403,7 @@ describe("BitbucketServer Integration Tests", () => {
             { action: "COMMENTED", user: { name: "user2" } },
             { action: "REVIEWED", user: { name: "user3" } },
           ],
+          isLastPage: true,
         },
       });
 
@@ -416,13 +417,14 @@ describe("BitbucketServer Integration Tests", () => {
       });
 
       const content = result.content as Array<{ type: string; text: string }>;
-      const parsed = JSON.parse(content[0].text);
+      const { values: parsed, isLastPage } = JSON.parse(content[0].text);
       expect(parsed).toHaveLength(2);
       expect(
         parsed.every((r: { action: string }) =>
           ["APPROVED", "REVIEWED"].includes(r.action),
         ),
       ).toBe(true);
+      expect(isLastPage).toBe(true);
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -322,6 +322,7 @@ describe("BitbucketServer", () => {
             { action: "COMMENTED", user: { name: "user2" } },
             { action: "REVIEWED", user: { name: "user3" } },
           ],
+          isLastPage: true,
         }),
       );
 
@@ -331,13 +332,14 @@ describe("BitbucketServer", () => {
         prId: 1,
       });
 
-      const reviews = JSON.parse(result.content[0].text);
+      const { values: reviews, isLastPage } = JSON.parse(result.content[0].text);
       expect(reviews).toHaveLength(2);
       expect(
         reviews.every((r: { action: string }) =>
           ["APPROVED", "REVIEWED"].includes(r.action),
         ),
       ).toBe(true);
+      expect(isLastPage).toBe(true);
     });
 
     test("should add comment with parent", async () => {
@@ -356,6 +358,224 @@ describe("BitbucketServer", () => {
         { text: "Test comment", parent: { id: 123 } },
       );
       expect(JSON.parse(result.content[0].text)).toEqual({ id: 456 });
+    });
+  });
+
+  describe("Activities / Comments / Reviews pagination", () => {
+    beforeEach(() => {
+      makeServer(BASE_ENV);
+    });
+
+    const ACTIVITIES_URL =
+      "/projects/TEST/repos/repo/pull-requests/1/activities";
+
+    // ---- start / limit pass-through ----------------------------------------
+
+    test("get_activities passes start and limit to the API", async () => {
+      mockApiGet.mockResolvedValueOnce(
+        createAxiosResponse({ values: [], isLastPage: true }),
+      );
+
+      await callTool("get_activities", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        start: 25,
+        limit: 50,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(ACTIVITIES_URL, {
+        params: { start: 25, limit: 50 },
+      });
+    });
+
+    test("get_comments passes start and limit to the API", async () => {
+      mockApiGet.mockResolvedValueOnce(
+        createAxiosResponse({ values: [], isLastPage: true }),
+      );
+
+      await callTool("get_comments", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        start: 25,
+        limit: 50,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(ACTIVITIES_URL, {
+        params: { start: 25, limit: 50 },
+      });
+    });
+
+    test("get_reviews passes start and limit to the API", async () => {
+      mockApiGet.mockResolvedValueOnce(
+        createAxiosResponse({ values: [], isLastPage: true }),
+      );
+
+      await callTool("get_reviews", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        start: 25,
+        limit: 50,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(ACTIVITIES_URL, {
+        params: { start: 25, limit: 50 },
+      });
+    });
+
+    test("get_activities without pagination sends no params", async () => {
+      mockApiGet.mockResolvedValueOnce(
+        createAxiosResponse({ values: [], isLastPage: true }),
+      );
+
+      await callTool("get_activities", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledWith(ACTIVITIES_URL, {
+        params: {},
+      });
+    });
+
+    // ---- fetchAll walks multiple pages --------------------------------------
+
+    test("get_activities with fetchAll walks all pages and returns merged values", async () => {
+      mockApiGet
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [{ action: "COMMENTED", id: 1 }],
+            isLastPage: false,
+            nextPageStart: 1,
+          }),
+        )
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [{ action: "APPROVED", id: 2 }],
+            isLastPage: true,
+          }),
+        );
+
+      const result = await callTool("get_activities", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        fetchAll: true,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledTimes(2);
+      expect(mockApiGet).toHaveBeenNthCalledWith(1, ACTIVITIES_URL, {
+        params: { start: 0, limit: 100 },
+      });
+      expect(mockApiGet).toHaveBeenNthCalledWith(2, ACTIVITIES_URL, {
+        params: { start: 1, limit: 100 },
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.values).toHaveLength(2);
+      expect(parsed.isLastPage).toBe(true);
+      expect(parsed.size).toBe(2);
+    });
+
+    test("get_comments with fetchAll filters COMMENTED across all pages", async () => {
+      mockApiGet
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [
+              { action: "COMMENTED", id: 1 },
+              { action: "APPROVED", id: 2 },
+            ],
+            isLastPage: false,
+            nextPageStart: 2,
+          }),
+        )
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [
+              { action: "COMMENTED", id: 3 },
+              { action: "REVIEWED", id: 4 },
+            ],
+            isLastPage: true,
+          }),
+        );
+
+      const result = await callTool("get_comments", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        fetchAll: true,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledTimes(2);
+      const comments = JSON.parse(result.content[0].text);
+      expect(comments).toHaveLength(2);
+      expect(comments.every((c: { action: string }) => c.action === "COMMENTED")).toBe(true);
+    });
+
+    test("get_reviews with fetchAll filters APPROVED and REVIEWED across all pages", async () => {
+      mockApiGet
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [
+              { action: "COMMENTED", id: 1 },
+              { action: "APPROVED", id: 2 },
+            ],
+            isLastPage: false,
+            nextPageStart: 2,
+          }),
+        )
+        .mockResolvedValueOnce(
+          createAxiosResponse({
+            values: [
+              { action: "REVIEWED", id: 3 },
+              { action: "COMMENTED", id: 4 },
+            ],
+            isLastPage: true,
+          }),
+        );
+
+      const result = await callTool("get_reviews", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        fetchAll: true,
+      });
+
+      expect(mockApiGet).toHaveBeenCalledTimes(2);
+      const reviews = JSON.parse(result.content[0].text);
+      expect(reviews).toHaveLength(2);
+      expect(
+        reviews.every((r: { action: string }) =>
+          ["APPROVED", "REVIEWED"].includes(r.action),
+        ),
+      ).toBe(true);
+    });
+
+    // ---- paged result exposes nextPageStart ---------------------------------
+
+    test("get_comments returns isLastPage and nextPageStart for further paging", async () => {
+      mockApiGet.mockResolvedValueOnce(
+        createAxiosResponse({
+          values: [{ action: "COMMENTED", id: 1 }],
+          isLastPage: false,
+          nextPageStart: 25,
+        }),
+      );
+
+      const result = await callTool("get_comments", {
+        project: "TEST",
+        repository: "repo",
+        prId: 1,
+        limit: 25,
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.isLastPage).toBe(false);
+      expect(parsed.nextPageStart).toBe(25);
+      expect(parsed.values).toHaveLength(1);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,12 @@ interface ListOptions {
   start?: number;
 }
 
+interface ActivitiesPaginationOptions {
+  start?: number;
+  limit?: number;
+  fetchAll?: boolean;
+}
+
 interface ListRepositoriesOptions extends ListOptions {
   project?: string;
 }
@@ -434,7 +440,10 @@ export class BitbucketServer {
             properties: {
               project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
               repository: { type: 'string', description: 'Repository slug containing the pull request.' },
-              prId: { type: 'number', description: 'Pull request ID to get reviews for.' }
+              prId: { type: 'number', description: 'Pull request ID to get reviews for.' },
+              start: { type: 'number', description: 'Page offset (0-based). Use nextPageStart from a previous response to fetch the next page.' },
+              limit: { type: 'number', description: 'Maximum number of activities to return per page (default: 25, max: 100).' },
+              fetchAll: { type: 'boolean', description: 'When true, fetches all pages and returns the complete review history. Recommended when thorough analysis is needed.' }
             },
             required: ['repository', 'prId']
           }
@@ -447,7 +456,10 @@ export class BitbucketServer {
             properties: {
               project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
               repository: { type: 'string', description: 'Repository slug containing the pull request.' },
-              prId: { type: 'number', description: 'Pull request ID to get activities for.' }
+              prId: { type: 'number', description: 'Pull request ID to get activities for.' },
+              start: { type: 'number', description: 'Page offset (0-based). Use nextPageStart from a previous response to fetch the next page.' },
+              limit: { type: 'number', description: 'Maximum number of activities to return per page (default: 25, max: 100).' },
+              fetchAll: { type: 'boolean', description: 'When true, fetches all pages and returns the complete activity history. Recommended when thorough analysis is needed.' }
             },
             required: ['repository', 'prId']
           }
@@ -460,7 +472,10 @@ export class BitbucketServer {
             properties: {
               project: { type: 'string', description: 'Bitbucket project key. If omitted, uses BITBUCKET_DEFAULT_PROJECT environment variable.' },
               repository: { type: 'string', description: 'Repository slug containing the pull request.' },
-              prId: { type: 'number', description: 'Pull request ID to get comments for.' }
+              prId: { type: 'number', description: 'Pull request ID to get comments for.' },
+              start: { type: 'number', description: 'Page offset (0-based). Use nextPageStart from a previous response to fetch the next page.' },
+              limit: { type: 'number', description: 'Maximum number of activities to return per page (default: 25, max: 100).' },
+              fetchAll: { type: 'boolean', description: 'When true, fetches all pages and returns the complete comment history. Recommended for PRs with many comments.' }
             },
             required: ['repository', 'prId']
           }
@@ -839,7 +854,11 @@ export class BitbucketServer {
               repository: args.repository as string,
               prId: args.prId as number
             };
-            return await this.getReviews(reviewsPrParams);
+            return await this.getReviews(reviewsPrParams, {
+              start: args.start as number | undefined,
+              limit: args.limit as number | undefined,
+              fetchAll: args.fetchAll as boolean | undefined
+            });
           }
 
           case 'get_activities': {
@@ -848,7 +867,11 @@ export class BitbucketServer {
               repository: args.repository as string,
               prId: args.prId as number
             };
-            return await this.getActivities(activitiesPrParams);
+            return await this.getActivities(activitiesPrParams, {
+              start: args.start as number | undefined,
+              limit: args.limit as number | undefined,
+              fetchAll: args.fetchAll as boolean | undefined
+            });
           }
 
           case 'get_comments': {
@@ -857,7 +880,11 @@ export class BitbucketServer {
               repository: args.repository as string,
               prId: args.prId as number
             };
-            return await this.getComments(commentsPrParams);
+            return await this.getComments(commentsPrParams, {
+              start: args.start as number | undefined,
+              limit: args.limit as number | undefined,
+              fetchAll: args.fetchAll as boolean | undefined
+            });
           }
 
           case 'search': {
@@ -1596,41 +1623,116 @@ export class BitbucketServer {
     };
   }
 
-  private async getReviews(params: PullRequestParams) {
+  private async fetchAllActivityValues(
+    project: string,
+    repository: string,
+    prId: number
+  ): Promise<BitbucketActivity[]> {
+    const allValues: BitbucketActivity[] = [];
+    let nextStart = 0;
+    let isLastPage = false;
+
+    while (!isLastPage) {
+      const response = await this.api.get(
+        `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`,
+        { params: { start: nextStart, limit: 100 } }
+      );
+      allValues.push(...(response.data.values as BitbucketActivity[]));
+      isLastPage = response.data.isLastPage as boolean;
+      nextStart = (response.data.nextPageStart as number) ?? 0;
+    }
+
+    return allValues;
+  }
+
+  private async getReviews(params: PullRequestParams, pagination: ActivitiesPaginationOptions = {}) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId) {
       throw new McpError(
         ErrorCode.InvalidParams,
         'Project, repository, and prId are required'
       );
     }
-    
+
+    const { start, limit, fetchAll } = pagination;
+
+    if (fetchAll) {
+      const allValues = await this.fetchAllActivityValues(project, repository, prId);
+      const reviews = allValues.filter(
+        (activity) => activity.action === 'APPROVED' || activity.action === 'REVIEWED'
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(reviews, null, 2) }]
+      };
+    }
+
+    const apiParams: Record<string, number> = {};
+
+    if (start !== undefined) {
+      apiParams.start = start;
+    }
+
+    if (limit !== undefined) {
+      apiParams.limit = limit;
+    }
+
     const response = await this.api.get(
-      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`,
+      { params: apiParams }
     );
 
-    const reviews = response.data.values.filter(
-      (activity: BitbucketActivity) => activity.action === 'APPROVED' || activity.action === 'REVIEWED'
+    const reviews = (response.data.values as BitbucketActivity[]).filter(
+      (activity) => activity.action === 'APPROVED' || activity.action === 'REVIEWED'
     );
 
     return {
-      content: [{ type: 'text', text: JSON.stringify(reviews, null, 2) }]
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          values: reviews,
+          isLastPage: response.data.isLastPage,
+          nextPageStart: response.data.nextPageStart
+        }, null, 2)
+      }]
     };
   }
 
-  private async getActivities(params: PullRequestParams) {
+  private async getActivities(params: PullRequestParams, pagination: ActivitiesPaginationOptions = {}) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId) {
       throw new McpError(
         ErrorCode.InvalidParams,
         'Project, repository, and prId are required'
       );
     }
-    
+
+    const { start, limit, fetchAll } = pagination;
+
+    if (fetchAll) {
+      const allValues = await this.fetchAllActivityValues(project, repository, prId);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ values: allValues, isLastPage: true, size: allValues.length }, null, 2)
+        }]
+      };
+    }
+
+    const apiParams: Record<string, number> = {};
+
+    if (start !== undefined) {
+      apiParams.start = start;
+    }
+
+    if (limit !== undefined) {
+      apiParams.limit = limit;
+    }
+
     const response = await this.api.get(
-      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`,
+      { params: apiParams }
     );
 
     return {
@@ -1638,26 +1740,54 @@ export class BitbucketServer {
     };
   }
 
-  private async getComments(params: PullRequestParams) {
+  private async getComments(params: PullRequestParams, pagination: ActivitiesPaginationOptions = {}) {
     const { project, repository, prId } = params;
-    
+
     if (!project || !repository || !prId) {
       throw new McpError(
         ErrorCode.InvalidParams,
         'Project, repository, and prId are required'
       );
     }
-    
+
+    const { start, limit, fetchAll } = pagination;
+
+    if (fetchAll) {
+      const allValues = await this.fetchAllActivityValues(project, repository, prId);
+      const comments = allValues.filter((activity) => activity.action === 'COMMENTED');
+      return {
+        content: [{ type: 'text', text: JSON.stringify(comments, null, 2) }]
+      };
+    }
+
+    const apiParams: Record<string, number> = {};
+
+    if (start !== undefined) {
+      apiParams.start = start;
+    }
+
+    if (limit !== undefined) {
+      apiParams.limit = limit;
+    }
+
     const response = await this.api.get(
-      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`
+      `/projects/${project}/repos/${repository}/pull-requests/${prId}/activities`,
+      { params: apiParams }
     );
 
-    const comments = response.data.values.filter(
-      (activity: BitbucketActivity) => activity.action === 'COMMENTED'
+    const comments = (response.data.values as BitbucketActivity[]).filter(
+      (activity) => activity.action === 'COMMENTED'
     );
 
     return {
-      content: [{ type: 'text', text: JSON.stringify(comments, null, 2) }]
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          values: comments,
+          isLastPage: response.data.isLastPage,
+          nextPageStart: response.data.nextPageStart
+        }, null, 2)
+      }]
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #35.

`get_activities`, `get_comments`, and `get_reviews` all hit `/pull-requests/{id}/activities` without pagination parameters. The endpoint defaults to a page size of 25, so older PR history is silently unreachable. For `get_comments` the effect compounds because the `COMMENTED` filter runs client-side on the first page only — returning as few as 10-15 comments on a chatty PR even though many more exist.

## Changes

Three optional parameters added to all three tools:

| Parameter | Type | Description |
|-----------|------|-------------|
| `start` | `number` | Page offset (0-based). Use `nextPageStart` from a previous response to fetch the next page. |
| `limit` | `number` | Activities per page (default: 25, max: 100). |
| `fetchAll` | `boolean` | When `true`, walks all pages internally and returns the complete history in one call. |

**`get_activities`** — without `fetchAll` now returns `{ values, isLastPage, nextPageStart }` so callers can page manually. With `fetchAll` returns `{ values, isLastPage: true, size }`.

**`get_comments` / `get_reviews`** — without `fetchAll` returns `{ values, isLastPage, nextPageStart }` with the filter already applied (so the caller knows whether to keep paging). With `fetchAll` the filter runs over the full activity set, not just the first page.

Default behaviour (no parameters) is fully backward-compatible.

## Tests

- `start` / `limit` are forwarded to axios as query params
- Default call (no params) sends empty params object
- `fetchAll` walks exactly the right number of pages following `nextPageStart`
- `get_comments` / `get_reviews` with `fetchAll` filter across all pages
- Paged response exposes `isLastPage` and `nextPageStart`