### PR TITLE
Fix Windows path comparison

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { parseCustomHeaders } from "./headers.js";
 import winston from 'winston';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'url';
 import fs from 'fs';
 
 // Resolve log file path: BITBUCKET_LOG_PATH env var > default (~/.bitbucket-server-mcp/bitbucket.log)
@@ -2267,7 +2268,10 @@ export class BitbucketServer {
 }
 
 // Entry point — only runs when this module is executed directly, not when imported.
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (
+  process.argv[1] && 
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
   const server = new BitbucketServer();
   server.run().catch((error) => {
     logger.error('Server error', error);


### PR DESCRIPTION
The change contains fix for following issue:
[https://github.com/garc33/bitbucket-server-mcp-server/issues/37](url)

**Issue**: The following condition was never true for windows (using mcp config file), as `new URL` adds leading forward slashes (/) in the path, which is by default not supported by windows.
```javascript
if (process.argv[1] === new URL(import.meta.url).pathname) {
```
<br>
<b>Fix</b>: The entry point condition is changed to use resolved paths and `fileURLToPath` inorder to compare, which works well on both linux system and windows system.

cc: @garc33 